### PR TITLE
Fix: use scope of `with`

### DIFF
--- a/charts/chromadb/templates/deployment.yaml
+++ b/charts/chromadb/templates/deployment.yaml
@@ -48,15 +48,15 @@ spec:
               protocol: TCP
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:


### PR DESCRIPTION
Global scope .Values is not available within `with`. Suggest using current scope of `with`.

This is breaking support for configuring probes and resources.

You can test the error with: `helm template . --debug --set livenessProbe.httpGet.path=/api/v1,livenessProbe.httpGet.port=8000`